### PR TITLE
Add simple Next.js frontend

### DIFF
--- a/.cursor/rules/frontend-rule.mdc
+++ b/.cursor/rules/frontend-rule.mdc
@@ -8,6 +8,7 @@ alwaysApply: false
 - You must pay attention to visual clarity and contrast. Do not place white text on a white background.
 - You must ensure the UX is pleasant. Boxes should grow to fit their contents, etc. 
 - When asking the user for sensitive information - you must use password style text-entry boxes in the UI.
-- You should use Next.js as it works best with Vercel. 
-- This frontend will ultimately be deployed on Vercel, but it should be possible to test locally. 
+- You should use Next.js as it works best with Vercel.
+- This frontend will ultimately be deployed on Vercel, but it should be possible to test locally.
 - Always provide users with a way to run the created UI once you have created it.
+- **Theme**: use a dark purple background (`#1a1a2e`) with turquoise accents (`#64ffda`). Text should be light grey.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,18 @@
-### Front End
+# 🎨 AI Engineer Frontend
 
-Please populate this README with instructions on how to run the application!
+This mini Next.js app lets you chat with the FastAPI backend.
+
+## 🚀 Running Locally
+
+1. Install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) in your browser.
+
+Make sure the backend in `/api` is running on port **8000** so the `/api/chat` route works while you test locally.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ai-engineer-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [developerMessage, setDeveloperMessage] = useState('');
+  const [userMessage, setUserMessage] = useState('');
+  const [response, setResponse] = useState('');
+  const [apiKey, setApiKey] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setResponse('');
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ developer_message: developerMessage, user_message: userMessage, api_key: apiKey })
+    });
+    if (!res.body) return;
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      setResponse((prev) => prev + decoder.decode(value));
+    }
+  }
+
+  return (
+    <div style={{ padding: '2rem', backgroundColor: '#1a1a2e', minHeight: '100vh', color: '#f0f0f0' }}>
+      <h1 style={{ color: '#64ffda' }}>AI Engineer Challenge</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 600 }}>
+        <textarea placeholder="Developer message" value={developerMessage} onChange={(e) => setDeveloperMessage(e.target.value)} required style={{ minHeight: '80px' }} />
+        <textarea placeholder="User message" value={userMessage} onChange={(e) => setUserMessage(e.target.value)} required style={{ minHeight: '80px' }} />
+        <input type="password" placeholder="OpenAI API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} required />
+        <button type="submit" style={{ backgroundColor: '#64ffda', color: '#1a1a2e', padding: '0.5rem', border: 'none', cursor: 'pointer' }}>Send</button>
+      </form>
+      {response && (
+        <div style={{ marginTop: '1rem', whiteSpace: 'pre-wrap' }}>
+          <h2 style={{ color: '#64ffda' }}>Response</h2>
+          <p>{response}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- implement minimal Next.js app under `frontend`
- document how to run the frontend
- specify color scheme in `frontend-rule.mdc`

## Testing
- `node -v`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a095d82d48322a30ba2d15560613d