### PR TITLE
Remove API key from client request

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -7,6 +7,7 @@ This is a FastAPI-based backend service that provides a streaming chat interface
 - Python 3.8 or higher
 - pip (Python package manager)
 - An OpenAI API key
+  - Set `OPENAI_API_KEY` in your environment before starting the server
 
 ## Setup
 
@@ -45,8 +46,7 @@ The server will start on `http://localhost:8000`
 {
     "developer_message": "string",
     "user_message": "string",
-    "model": "gpt-4.1-mini",  // optional
-    "api_key": "your-openai-api-key"
+    "model": "gpt-4.1-mini"  // optional
 }
 ```
 - **Response**: Streaming text response

--- a/api/app.py
+++ b/api/app.py
@@ -28,14 +28,17 @@ class ChatRequest(BaseModel):
     developer_message: str  # Message from the developer/system
     user_message: str      # Message from the user
     model: Optional[str] = "gpt-4.1-mini"  # Optional model selection with default
-    api_key: str          # OpenAI API key for authentication
 
 # Define the main chat endpoint that handles POST requests
 @app.post("/api/chat")
 async def chat(request: ChatRequest):
     try:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise HTTPException(status_code=500, detail="OPENAI_API_KEY not set")
+
         # Initialize OpenAI client with the provided API key
-        client = OpenAI(api_key=request.api_key)
+        client = OpenAI(api_key=api_key)
         
         # Create an async generator function for streaming responses
         async def generate():

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,4 +15,4 @@ This mini Next.js app lets you chat with the FastAPI backend.
    ```
 3. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-Make sure the backend in `/api` is running on port **8000** so the `/api/chat` route works while you test locally.
+Make sure the backend in `/api` is running on port **8000** and that `OPENAI_API_KEY` is set before starting the server so the `/api/chat` route works while you test locally.

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -4,7 +4,6 @@ export default function Home() {
   const [developerMessage, setDeveloperMessage] = useState('');
   const [userMessage, setUserMessage] = useState('');
   const [response, setResponse] = useState('');
-  const [apiKey, setApiKey] = useState('');
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -12,7 +11,7 @@ export default function Home() {
     const res = await fetch('/api/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ developer_message: developerMessage, user_message: userMessage, api_key: apiKey })
+      body: JSON.stringify({ developer_message: developerMessage, user_message: userMessage })
     });
     if (!res.body) return;
     const reader = res.body.getReader();
@@ -30,7 +29,6 @@ export default function Home() {
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 600 }}>
         <textarea placeholder="Developer message" value={developerMessage} onChange={(e) => setDeveloperMessage(e.target.value)} required style={{ minHeight: '80px' }} />
         <textarea placeholder="User message" value={userMessage} onChange={(e) => setUserMessage(e.target.value)} required style={{ minHeight: '80px' }} />
-        <input type="password" placeholder="OpenAI API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} required />
         <button type="submit" style={{ backgroundColor: '#64ffda', color: '#1a1a2e', padding: '0.5rem', border: 'none', cursor: 'pointer' }}>Send</button>
       </form>
       {response && (


### PR DESCRIPTION
## Summary
- read `OPENAI_API_KEY` from the environment in the FastAPI backend
- adjust request model and docs to remove the `api_key` field
- update Next.js frontend to stop asking for an API key
- mention new env var requirement in documentation

## Testing
- `python -m py_compile api/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a1ee7929c83229b279137db342ce6