### PR TITLE
Retro style frontend

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from 'next/app'
+import '../styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -25,17 +25,35 @@ export default function Home() {
   }
 
   return (
-    <div style={{ padding: '2rem', backgroundColor: '#1a1a2e', minHeight: '100vh', color: '#f0f0f0' }}>
-      <h1 style={{ color: '#64ffda' }}>AI Engineer Challenge</h1>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 600 }}>
-        <textarea placeholder="Developer message" value={developerMessage} onChange={(e) => setDeveloperMessage(e.target.value)} required style={{ minHeight: '80px' }} />
-        <textarea placeholder="User message" value={userMessage} onChange={(e) => setUserMessage(e.target.value)} required style={{ minHeight: '80px' }} />
-        <input type="password" placeholder="OpenAI API Key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} required />
-        <button type="submit" style={{ backgroundColor: '#64ffda', color: '#1a1a2e', padding: '0.5rem', border: 'none', cursor: 'pointer' }}>Send</button>
+    <div className="container">
+      <h1>AI Engineer Challenge</h1>
+      <form onSubmit={handleSubmit}>
+        <textarea
+          placeholder="Developer message"
+          value={developerMessage}
+          onChange={(e) => setDeveloperMessage(e.target.value)}
+          required
+          style={{ minHeight: '80px' }}
+        />
+        <textarea
+          placeholder="User message"
+          value={userMessage}
+          onChange={(e) => setUserMessage(e.target.value)}
+          required
+          style={{ minHeight: '80px' }}
+        />
+        <input
+          type="password"
+          placeholder="OpenAI API Key"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          required
+        />
+        <button type="submit">Send</button>
       </form>
       {response && (
         <div style={{ marginTop: '1rem', whiteSpace: 'pre-wrap' }}>
-          <h2 style={{ color: '#64ffda' }}>Response</h2>
+          <h2>Response</h2>
           <p>{response}</p>
         </div>
       )}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,44 @@
+body {
+  background-color: #110022;
+  color: #00ffcc;
+  font-family: 'Courier New', Courier, monospace;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.container {
+  padding: 2rem;
+}
+
+h1 {
+  color: #ffcc00;
+  text-shadow: 2px 2px 4px #ff00aa;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+textarea,
+input[type="password"] {
+  background-color: #280b52;
+  color: #00ffcc;
+  border: 2px solid #00ffcc;
+  padding: 0.5rem;
+}
+
+button {
+  background-color: #ff00aa;
+  color: #ffffff;
+  padding: 0.5rem;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 0 6px #ff00aa;
+}
+
+h2 {
+  color: #ffcc00;
+}


### PR DESCRIPTION
## Summary
- switch frontend layout to CSS classes
- add retro global styling

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a20653c148322a08d41d1aecbf9c6