### PR TITLE
Fix global CSS import by switching to app router

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,16 @@
+import '../styles/globals.css';
+
+export const metadata = {
+  title: 'AI Engineer Challenge',
+  description: 'Frontend for the AI Engineer Challenge',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from 'react';
 
 export default function Home() {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,0 @@
-import type { AppProps } from 'next/app'
-import '../styles/globals.css';
-
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
-}


### PR DESCRIPTION
## Summary
- switch Next.js project to use new `app` router
- move home page to `app/page.tsx`
- load global styles in `app/layout.tsx`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684a25b7acbc83228951c21210ccb74b